### PR TITLE
Added lanuage: c to the Travis CI YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: c
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
Specifying the language allows Travis to build with clang and gcc. It also prevents unnecessary ruby related processes from running during CI builds.
